### PR TITLE
Create Hama-mini-builtin

### DIFF
--- a/src/resource/Hama-mini-builtin
+++ b/src/resource/Hama-mini-builtin
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<palette>
+	<color><r>255</r><g>255</g><b>255</b><name>HM1 White</name></color>
+	<color><r>241</r><g>218</g><b>214</b><name>HM2 Creme</name></color>
+	<color><r>247</r><g>244</g><b>27</b><name>HM3 Yellow</name></color>
+	<color><r>229</r><g>108</g><b>20</b><name>HM4 Orange</name></color>
+	<color><r>203</r><g>10</g><b>10</b><name>HM5 Red</name></color>
+	<color><r>255</r><g>196</g><b>239</b><name>HM6 Pink</name></color>
+	<color><r>128</r><g>61</g><b>184</b><name>HM7 Purple</name></color>
+	<color><r>46</r><g>54</g><b>166</b><name>HM8 Blue</name></color>
+	<color><r>77</r><g>87</g><b>220</b><name>HM9 Light Blue</name></color>
+	<color><r>32</r><g>118</g><b>23</b><name>HM10 Green</name></color>
+	<color><r>142</r><g>234</g><b>177</b><name>HM11 Light Green</name></color>
+	<color><r>63</r><g>46</g><b>16</b><name>HM12 Brown</name></color>
+	<color><r>149</r><g>149</g><b>149</b><name>HM17 Grey</name></color>
+	<color><r>0</r><g>0</g><b>0</b><name>HM18 Black</name></color>
+	<color><r>164</r><g>76</g><b>46</b><name>HM20 Reddish Brown</name></color>
+	<color><r>182</r><g>109</g><b>49</b><name>HM21 Light Brown</name></color>
+	<color><r>133</r><g>3</g><b>38</b><name>HM22 Dark Red</name></color>
+	<color><r>241</r><g>210</g><b>193</b><name>HM26 Flesh</name></color>
+	<color><r>238</r><g>212</g><b>170</b><name>HM27 Beige</name></color>
+	<color><r>7</r><g>61</g><b>7</b><name>HM28 Dark Green</name></color>
+	<color><r>179</r><g>36</g><b>96</b><name>HM29 Claret</name></color>
+	<color><r>79</r><g>16</g><b>43</b><name>HM30 Burgundy</name></color>
+	<color><r>93</r><g>150</g><b>176</b><name>HM31 Turguoise</name></color>
+	<color><r>220</r><g>145</g><b>205</b><name>HM32 Fuchsia</name></color>
+	<color><r>239</r><g>70</g><b>62</b><name>HM33 Cerise Pink</name></color>
+	<color><r>232</r><g>244</g><b>70</b><name>HM43 Pastel Yellow</name></color>
+	<color><r>251</r><g>155</g><b>136</b><name>HM44 Pastel Red</name></color>
+	<color><r>171</r><g>136</g><b>251</b><name>HM45 Pastel Purple</name></color>
+	<color><r>121</r><g>194</g><b>255</b><name>HM46 Pastel Blue</name></color>
+	<color><r>153</r><g>255</g><b>103</b><name>HM47 Pastel Green</name></color>
+	<color><r>213</r><g>125</g><b>226</b><name>HM48 Pastel Pink</name></color>
+	<color><r>0</r><g>174</g><b>224</b><name>HM49 Azure</name></color>
+	<color><r>237</r><g>125</g><b>57</b><name>HM60 Teddybear Brown</name></color>
+	<color><r>169</r><g>179</g><b>180</b><name>HM70 Light Grey</name></color>
+	<color><r>81</r><g>86</g><b>89</b><name>HM71 Dark Grey</name></color>
+	<color><r>209</r><g>147</g><b>94</b><name>HM75 Tan</name></color>
+	<color><r>157</r><g>87</g><b>47</b><name>HM76 Nougat</name></color>
+</palette>


### PR DESCRIPTION
All new colors for Hama mini beads.
I just found out that as far as I can tell, the above are the same currently for the midi beads.
So, you'd be better off overwriting the hama-builtin with this list.
I used Photoshop to get the colors from the website, but I have no clue if this will be the best way to get the right colors.
They seem to look right. Haven't changed the ones that were already added  by you.
Flesh has changed from 25 to 26 btw.